### PR TITLE
move firewall mgmt to its own task files, make it optional, add ufw 

### DIFF
--- a/tasks/firewall-enable.yml
+++ b/tasks/firewall-enable.yml
@@ -1,0 +1,32 @@
+###########################
+## Firewall management
+##########################
+
+##  firewalld - Allow WireGuard service, add network interface on firewall and enable masquerading
+
+  - name: Allow WireGuard service for FirewallD public zone
+    firewalld:
+      zone: public
+      service: wireguard
+      state: enabled
+      permanent: yes
+      immediate: yes
+    when: use_firewalld
+
+  - name: Add WireGuard interface to FirewallD public zone
+    firewalld:
+      zone: public
+      interface: wg0
+      state: enabled
+      permanent: yes
+      immediate: yes
+    when: use_firewalld
+    
+  - name: Enable Masquerading
+    firewalld:
+      zone: public
+      masquerade: yes
+      state: enabled
+      permanent: yes
+      immediate: yes
+    when: use_firewalld  

--- a/tasks/firewall-setup.yml
+++ b/tasks/firewall-setup.yml
@@ -1,0 +1,47 @@
+###########################
+## Firewall setup
+##########################
+
+## Firewalld rules first
+
+- name: Install FirewallD
+  package:
+    name: firewalld
+    state: latest
+  when: use_firewalld
+
+
+- name: Enable and start FirewallD service
+  service:
+    name: firewalld
+    state: started
+    enabled: yes
+  when: use_firewalld
+
+
+## Add WireGuard service to FirewallD services
+
+- name: Add WireGuard as a service to FirewallD
+  template:
+    src: wireguard.xml.j2
+    dest: /etc/firewalld/services/wireguard.xml
+    owner: root
+    group: root
+    mode: 0600
+    force: no
+  when: use_firewalld
+
+
+## UFW rules second
+- name: Ensure UFW is installed
+  package:
+    name: ufw
+    state: present
+  when: use_ufw
+  
+- name: Setup ufw
+  ufw:
+    rule: allow
+    proto: udp
+    port: "{{wireguard_port}}"
+  when: use_ufw

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,17 +93,7 @@
         reload: yes
 
 
-    - name: Install FirewallD
-      package:
-        name: firewalld
-        state: latest
 
-
-    - name: Enable and start FirewallD service
-      service:
-        name: firewalld
-        state: started
-        enabled: yes
 
 ## Configure WireGuard
     
@@ -132,17 +122,12 @@
         mode: 0600
         force: no
 
-## Add WireGuard service to FirewallD services
+## Set up the firewall if we're gonna
+    - name: Set up the firewall
+      import_tasks: firewall-setup.yml
+      when: manage_firewall
 
-    - name: Add WireGuard as a service to FirewallD
-      template:
-        src: wireguard.xml.j2
-        dest: /etc/firewalld/services/wireguard.xml
-        owner: root
-        group: root
-        mode: 0600
-        force: no
-
+      
 ## Reboot server to load latest kernel
 
     - name: Reboot server
@@ -161,34 +146,10 @@
       shell: apt install -y linux-headers-`uname -r`
       when: ansible_os_family == 'Debian'
 
-##  Allow WireGuard service, add network interface on firewall and enable masquerading
-
-    - name: Allow WireGuard service for FirewallD public zone
-      firewalld:
-        zone: public
-        service: wireguard
-        state: enabled
-        permanent: yes
-        immediate: yes
-
-
-    - name: Add WireGuard interface to FirewallD public zone
-      firewalld:
-        zone: public
-        interface: wg0
-        state: enabled
-        permanent: yes
-        immediate: yes
-
-
-    - name: Enable Masquerading
-      firewalld:
-        zone: public
-        masquerade: yes
-        state: enabled
-        permanent: yes
-        immediate: yes
-        
+## Enable the firewall if it isn't already
+    - name: Enable the firewall
+      import_tasks: firewall-enable.yml
+      when: manage_firewall
 
 ## Enable WireGuard kernel module and start service
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,3 +7,7 @@ wireguard_repo: "https://copr.fedorainfracloud.org/coprs/jdoss/wireguard/repo/ep
 wireguard_interface_ip: "10.0.0.1/24" # IPADDR/PREFIX
 wireguard_port: "51820"
 
+## Firewall settings
+manage_firewall: true
+use_firewalld: ansible_os_family == 'RedHat'
+use_ufw: not use_firewalld


### PR DESCRIPTION
I manage my firewall in another role so I moved the firewall management into its own file and import it based on the var manage_firewall.  


I also added rules for ufw for people that don't use firewalld