### PR TITLE
create a mesh network by specifying Peer definitions for a set of hosts

### DIFF
--- a/tasks/firewall-enable.yml
+++ b/tasks/firewall-enable.yml
@@ -1,0 +1,32 @@
+###########################
+## Firewall management
+##########################
+
+##  firewalld - Allow WireGuard service, add network interface on firewall and enable masquerading
+
+  - name: Allow WireGuard service for FirewallD public zone
+    firewalld:
+      zone: public
+      service: wireguard
+      state: enabled
+      permanent: yes
+      immediate: yes
+    when: use_firewalld
+
+  - name: Add WireGuard interface to FirewallD public zone
+    firewalld:
+      zone: public
+      interface: wg0
+      state: enabled
+      permanent: yes
+      immediate: yes
+    when: use_firewalld
+    
+  - name: Enable Masquerading
+    firewalld:
+      zone: public
+      masquerade: yes
+      state: enabled
+      permanent: yes
+      immediate: yes
+    when: use_firewalld  

--- a/tasks/firewall-setup.yml
+++ b/tasks/firewall-setup.yml
@@ -1,0 +1,47 @@
+###########################
+## Firewall setup
+##########################
+
+## Firewalld rules first
+
+- name: Install FirewallD
+  package:
+    name: firewalld
+    state: latest
+  when: use_firewalld
+
+
+- name: Enable and start FirewallD service
+  service:
+    name: firewalld
+    state: started
+    enabled: yes
+  when: use_firewalld
+
+
+## Add WireGuard service to FirewallD services
+
+- name: Add WireGuard as a service to FirewallD
+  template:
+    src: wireguard.xml.j2
+    dest: /etc/firewalld/services/wireguard.xml
+    owner: root
+    group: root
+    mode: 0600
+    force: no
+  when: use_firewalld
+
+
+## UFW rules second
+- name: Ensure UFW is installed
+  package:
+    name: ufw
+    state: present
+  when: use_ufw
+  
+- name: Setup ufw
+  ufw:
+    rule: allow
+    proto: udp
+    port: "{{wireguard_port}}"
+  when: use_ufw

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,6 +112,14 @@
         src: /etc/wireguard/privatekey
       register: wg_privatekey
 
+    - name: Register WireGuard public key as a variable
+      slurp:
+        src: /etc/wireguard/publickey
+      register: wg_publickey
+
+    - name: Store the public key in the host so it can be used in the template when setting Peers
+      set_fact:
+        wg_PublicKey: "{{ wg_publickey['content'] | b64decode | truncate(44,true,'')  }}"
 
     - name: Generate WireGuard configuration file
       template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,17 +93,7 @@
         reload: yes
 
 
-    - name: Install FirewallD
-      package:
-        name: firewalld
-        state: latest
 
-
-    - name: Enable and start FirewallD service
-      service:
-        name: firewalld
-        state: started
-        enabled: yes
 
 ## Configure WireGuard
     
@@ -132,17 +122,12 @@
         mode: 0600
         force: no
 
-## Add WireGuard service to FirewallD services
+## Set up the firewall if we're gonna
+    - name: Set up the firewall
+      import_tasks: firewall-setup.yml
+      when: manage_firewall
 
-    - name: Add WireGuard as a service to FirewallD
-      template:
-        src: wireguard.xml.j2
-        dest: /etc/firewalld/services/wireguard.xml
-        owner: root
-        group: root
-        mode: 0600
-        force: no
-
+      
 ## Reboot server to load latest kernel
 
     - name: Reboot server
@@ -161,34 +146,10 @@
       shell: apt install -y linux-headers-`uname -r`
       when: ansible_os_family == 'Debian'
 
-##  Allow WireGuard service, add network interface on firewall and enable masquerading
-
-    - name: Allow WireGuard service for FirewallD public zone
-      firewalld:
-        zone: public
-        service: wireguard
-        state: enabled
-        permanent: yes
-        immediate: yes
-
-
-    - name: Add WireGuard interface to FirewallD public zone
-      firewalld:
-        zone: public
-        interface: wg0
-        state: enabled
-        permanent: yes
-        immediate: yes
-
-
-    - name: Enable Masquerading
-      firewalld:
-        zone: public
-        masquerade: yes
-        state: enabled
-        permanent: yes
-        immediate: yes
-        
+## Enable the firewall if it isn't already
+    - name: Enable the firewall
+      import_tasks: firewall-enable.yml
+      when: manage_firewall
 
 ## Enable WireGuard kernel module and start service
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -128,13 +128,14 @@
         owner: root
         group: root
         mode: 0600
-        force: no
+        force: yes
 
 ## Set up the firewall if we're gonna
     - name: Set up the firewall
       import_tasks: firewall-setup.yml
       when: manage_firewall
-
+      tags:
+        - firewall
       
 ## Reboot server to load latest kernel
 
@@ -158,7 +159,9 @@
     - name: Enable the firewall
       import_tasks: firewall-enable.yml
       when: manage_firewall
-
+      tags:
+        - firewall
+      
 ## Enable WireGuard kernel module and start service
 
     - name: Enable WireGuard kernel module

--- a/templates/wireguard.conf.j2
+++ b/templates/wireguard.conf.j2
@@ -2,3 +2,13 @@
 Address = {{ wireguard_interface_ip }}
 ListenPort = {{ wireguard_port }}
 PrivateKey = {{ wg_privatekey['content'] | b64decode }}
+
+{% for nodename in ansible_play_hosts %}
+{% if ansible_nodename != nodename %}
+[Peer]
+PublicKey = {{hostvars[nodename]['wg_PublicKey']}} 
+AllowedIPs = {{hostvars[nodename]['wireguard_interface_ip']}}/32
+Endpoint = {{hostvars[nodename]['ansible_default_ipv4']['address']}}:{{wireguard_port}}
+{% endif %}
+
+{% endfor %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,3 +7,7 @@ wireguard_repo: "https://copr.fedorainfracloud.org/coprs/jdoss/wireguard/repo/ep
 wireguard_interface_ip: "10.0.0.1/24" # IPADDR/PREFIX
 wireguard_port: "51820"
 
+## Firewall settings
+manage_firewall: true
+use_firewalld: ansible_os_family == 'RedHat'
+use_ufw: not use_firewalld

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,7 +4,7 @@
 
 wireguard_repo: "https://copr.fedorainfracloud.org/coprs/jdoss/wireguard/repo/epel-7/jdoss-wireguard-epel-7.repo"
 
-wireguard_interface_ip: "10.0.0.1/24" # IPADDR/PREFIX
+#wireguard_interface_ip: "10.0.0.1/24" # IPADDR/PREFIX should be set in the host_vars file for each host
 wireguard_port: "51820"
 
 ## Firewall settings

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,4 +10,4 @@ wireguard_port: "51820"
 ## Firewall settings
 manage_firewall: true
 use_firewalld: ansible_os_family == 'RedHat'
-use_ufw: not use_firewalld
+use_ufw: ansible_os_family == 'Debian'


### PR DESCRIPTION
The for loop in the `wireguard.conf.j2` template iterates over the hosts actively running the playbook and for each host that isn't the host the play is currently running on it creates a Peer definition.  

The ansible_nodename variable is used to exclude the current host so  node names have to be unique in the set of hosts running.  

Each host should define their own `wireguard_interface_ip` variable e.g. in their file in the `host_vars` directory.


Should work on Redhat and Debian but I've only tested on Ubuntu 16.04


It doesn't do anything with the hosts file yet.  Think it should?  If so, what? 