### PR TITLE
Don't clobber existing keys

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,10 +111,17 @@
       file:
         dest: /etc/wireguard
         state: directory
+        
+        
+    - name: Test for existing keys
+      stat:
+        path: /etc/wireguard/privatekey
+      register: key_check
 
 
     - name: Generate WireGuard private and public keys
       shell: umask 077 && wg genkey | tee /etc/wireguard/privatekey | wg pubkey > /etc/wireguard/publickey
+      when: key_check.stat.exists == False
 
 
     - name: Register WireGuard private key as a variable


### PR DESCRIPTION
Previous to this commit the role did not check for pre-existing keys. This meant the role was not idempotent and would cause client configurations using the server public key to become invalid after each run. I added a stat for a Wireguard private key so that this role is now idempotent.